### PR TITLE
Fix jittery card animation on scroll

### DIFF
--- a/script.js
+++ b/script.js
@@ -374,41 +374,43 @@ if (window.innerWidth < 1000) {
   const scaleMax = gsap.utils.mapRange(1, cards.length - 1, 0.8, 1);
   const time = 3;
 
-  gsap.set(cards, {
-    y: 0,
-    transformStyle: "preserve-3d",
-    transformPerspective: 800,
-    transformOrigin: "center top"
-  });
+  const initCards = () => {
+    gsap.set(cards, {
+      y: 0,
+      zIndex: (i) => cards.length - i,
+      transformStyle: 'preserve-3d',
+      transformPerspective: 800,
+      transformOrigin: 'center top',
+      backfaceVisibility: 'hidden'
+    });
+    gsap.set(cards.slice(1), {
+      y: (i) => 20 * (i + 1)
+    });
+  };
 
-  gsap.set(cards.slice(1), {
-    y: (i) => 20 * (i + 1)
-  });
+  initCards();
 
   const tl = gsap.timeline({
     scrollTrigger: {
-      trigger: ".cards-inner",
-      start: "center center",
-      end: "+=300%",
+      trigger: '.cards-inner',
+      start: 'center center',
+      end: '+=300%',
       scrub: 0.8,
       pin: true,
       markers: true,
       pinSpacing: true,
       anticipatePin: 1,
-      onRefresh: self => {
-        if (self.progress === 1) {
-          gsap.set(cards, { clearProps: "all" });
-        }
-      },
-      onLeave: () => gsap.set(cards, { clearProps: "all" })
+      onEnter: initCards,
+      onEnterBack: initCards,
+      onLeave: () => gsap.set(cards, { clearProps: 'all' }),
+      onLeaveBack: () => gsap.set(cards, { clearProps: 'all' })
     }
   });
 
   tl.from(cards[0], {
     y: 60,
     duration: time * 0.2,
-    ease: "power2.out",
-    immediateRender: false
+    ease: 'power2.out'
   }, 0);
 
   tl.from(cards.slice(1), {
@@ -416,7 +418,7 @@ if (window.innerWidth < 1000) {
     duration: time,
     stagger: {
       each: time,
-      from: "start"
+      from: 'start'
     }
   }, 0);
 
@@ -425,20 +427,23 @@ if (window.innerWidth < 1000) {
     scale: (i) => scaleMax(i + 1),
     stagger: {
       each: time,
-      from: "start"
+      from: 'start'
     }
+  }, time);
+
+  tl.to(cards[cards.length - 1], {
+    y: '+=20',
+    duration: time * 0.2,
+    ease: 'power2.out'
   }, time);
 
   tl.to(cards, {
     rotationX: 0,
     scale: 1,
-    y: 0,
     duration: 1,
-    ease: "power2.out",
-  }, "+=0.5");
+    ease: 'power2.out'
+  }, '+=0.5');
 }
-
-
 //Fade-in
 
 gsap.utils.toArray(".fade-in-blur").forEach((element) => {

--- a/script.js
+++ b/script.js
@@ -399,14 +399,16 @@ if (window.innerWidth < 1000) {
         if (self.progress === 1) {
           gsap.set(cards, { clearProps: "all" });
         }
-      }
+      },
+      onLeave: () => gsap.set(cards, { clearProps: "all" })
     }
   });
 
   tl.from(cards[0], {
     y: 60,
     duration: time * 0.2,
-    ease: "power2.out"
+    ease: "power2.out",
+    immediateRender: false
   }, 0);
 
   tl.from(cards.slice(1), {

--- a/script.js
+++ b/script.js
@@ -370,18 +370,18 @@ if (window.innerWidth < 1000) {
 //cards
 
 if (window.innerWidth < 1000) {
-  const scaleMax = gsap.utils.mapRange(1, document.querySelectorAll(".cards__block").length - 1, 0.8, 1);
-  const time = 3; 
+  const cards = gsap.utils.toArray('.cards__block');
+  const scaleMax = gsap.utils.mapRange(1, cards.length - 1, 0.8, 1);
+  const time = 3;
 
-
-  gsap.set('.cards__block', {
+  gsap.set(cards, {
     y: 0,
     transformStyle: "preserve-3d",
     transformPerspective: 800,
     transformOrigin: "center top"
   });
 
-  gsap.set('.cards__block:not(:first-child)', {
+  gsap.set(cards.slice(1), {
     y: (i) => 20 * (i + 1)
   });
 
@@ -403,30 +403,37 @@ if (window.innerWidth < 1000) {
     }
   });
 
-  tl.from(".cards__block:not(:first-child)", {
+  tl.from(cards[0], {
+    y: 60,
+    duration: time * 0.2,
+    ease: "power2.out"
+  }, 0);
+
+  tl.from(cards.slice(1), {
     y: () => window.innerHeight,
     duration: time,
     stagger: {
       each: time,
-      from: "start" 
+      from: "start"
     }
-  }, 0); 
+  }, 0);
 
-  tl.to(".cards__block:not(:last-child)", {
+  tl.to(cards.slice(0, -1), {
     rotationX: -20,
-    scale: (i) => scaleMax(i),
+    scale: (i) => scaleMax(i + 1),
     stagger: {
       each: time,
       from: "start"
     }
-  }, time * 0.5);
+  }, time);
 
-  tl.to(".cards__block", {
+  tl.to(cards, {
     rotationX: 0,
     scale: 1,
+    y: 0,
     duration: 1,
     ease: "power2.out",
-  }, ">0.5"); 
+  }, "+=0.5");
 }
 
 

--- a/style.css
+++ b/style.css
@@ -2589,8 +2589,8 @@ input[type=number]::-webkit-outer-spin-button {
         min-height: auto;
         will-change: transform, opacity;
         transition: none !important;
-
-        
+        transform: translate3d(0, 0, 0);
+        backface-visibility: hidden;
       }
       
 

--- a/style.css
+++ b/style.css
@@ -370,6 +370,8 @@ body {
     position: relative;
     justify-content: center;
     overflow: hidden;
+    backface-visibility: hidden;
+    will-change: transform;
 }
 
 .cards__block-icons {


### PR DESCRIPTION
## Summary
- smooth mobile card stacking animation by delaying rotation and final reset
- define card list to clear properties and reset transforms
- ease first card into pinned position to prevent abrupt stop

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a027d011c0832c99d0939972f8a8a0