### PR TITLE
feat: add scroll stacking animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -493,3 +493,60 @@ menuLinks.forEach((link) => {
     body.classList.remove("menu-open");
   });
 });
+
+// cards stacking animation
+document.addEventListener("DOMContentLoaded", () => {
+  const section = document.querySelector(".cards-inner");
+  if (!section) return;
+
+  const cards = Array.from(section.querySelectorAll(".cards__block"));
+  if (!cards.length) return;
+
+  const placeholders = [];
+
+  cards.forEach((card) => {
+    const placeholder = document.createElement("div");
+    placeholder.style.height = `${card.offsetHeight}px`;
+    placeholder.style.width = `${card.offsetWidth}px`;
+    section.insertBefore(placeholder, card);
+    placeholders.push(placeholder);
+
+    card.classList.add("fixed-card");
+    card.style.visibility = "hidden";
+  });
+
+  const update = () => {
+    const center = window.innerHeight / 2;
+    const totalStacked = placeholders.filter(
+      (ph) => ph.getBoundingClientRect().top + ph.offsetHeight / 2 <= center
+    ).length;
+
+    const lastPlaceholder = placeholders[placeholders.length - 1];
+    if (
+      lastPlaceholder.getBoundingClientRect().top <=
+      -lastPlaceholder.offsetHeight
+    ) {
+      cards.forEach((card) => {
+        card.style.visibility = "hidden";
+        card.style.transform = "translate(-50%, -50%)";
+      });
+      return;
+    }
+
+    cards.forEach((card, i) => {
+      if (i < totalStacked) {
+        const depth = totalStacked - i - 1;
+        card.style.visibility = "visible";
+        card.style.transform = `translate(-50%, -50%) translateY(${depth * 25}px) scale(${1 - depth * 0.05})`;
+        card.style.zIndex = `${100 - depth}`;
+      } else {
+        card.style.visibility = "hidden";
+        card.style.transform = "translate(-50%, -50%)";
+        card.style.zIndex = "";
+      }
+    });
+  };
+
+  window.addEventListener("scroll", update);
+  update();
+});

--- a/style.css
+++ b/style.css
@@ -4298,7 +4298,7 @@ body.menu-open {
         overflow: hidden;
     }
 
-    .progress-fill {
+.progress-fill {
         position: absolute;
         top: 0;
         left: 0;
@@ -4308,6 +4308,16 @@ body.menu-open {
         border-radius: 12px;
         transition: width 0.1s linear;
     }
+}
+
+/* ----- stacked cards animation ----- */
+.cards__block.fixed-card {
+    position: fixed;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    will-change: transform;
+    transition: transform 0.3s ease;
 }
 
 


### PR DESCRIPTION
## Summary
- implement scroll-triggered card stacking animation that offsets and scales cards as they overlap
- add CSS helper class for fixed positioned cards during stacking

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a04aad716c832ca2a17441b3e770b1